### PR TITLE
New option to convert standard dolibarr ODT to PDF

### DIFF
--- a/admin/config.php
+++ b/admin/config.php
@@ -327,9 +327,20 @@ function showFormModel($typeDoc='propal', $entity = 1) {
             
             ?></td>             
         </tr>
-        
-        
-        
+</table>        
+<br /><br />   
+<table width="100%" class="noborder" style="background-color: #fff;">
+        <tr class="liste_titre">
+            <td colspan="2"><?php echo $langs->trans('DefaultDolibarrODT') ?></td>
+        </tr>        
+        <tr>
+            <td><?php echo $langs->trans('setODTDOCS_REPLACE_ADD_PDF_CONV_TO_STD_ODT') ?></td>
+            <td><?php print ajax_constantonoff('ODTDOCS_REPLACE_ADD_PDF_CONV_TO_STD_ODT'); ?></td>             
+        </tr>
+        <tr>
+            <td><?php echo $langs->trans('setODTDOCS_KEEP_ONLY_PDF') ?></td>
+            <td><?php print ajax_constantonoff('ODTDOCS_KEEP_ONLY_PDF'); ?></td>             
+        </tr>
 </table>
 <br /><br />
 <table width="100%" class="noborder">

--- a/admin/config.php
+++ b/admin/config.php
@@ -328,7 +328,22 @@ function showFormModel($typeDoc='propal', $entity = 1) {
             ?></td>             
         </tr>
 </table>        
-<br /><br />   
+<br /><br /> 
+<?php 
+
+dol_include_once('abricot/includes/class/class.template.tbs.php');
+// test abricot module compatibility
+$TTemplateTBS = new TTemplateTBS();
+if (method_exists($TTemplateTBS, 'convertToPDF'))
+{
+    $reflection = new ReflectionMethod($TTemplateTBS, 'convertToPDF');
+    if (!$reflection->isPublic()) {
+        print '<div class="error" >'.$langs->trans('ODTDOCS_needAbricotUpdate').'</div>';
+    }
+}
+unset($TTemplateTBS);
+
+?>
 <table width="100%" class="noborder" style="background-color: #fff;">
         <tr class="liste_titre">
             <td colspan="2"><?php echo $langs->trans('DefaultDolibarrODT') ?></td>

--- a/class/actions_odtdocs.class.php
+++ b/class/actions_odtdocs.class.php
@@ -64,6 +64,23 @@ class ActionsOdtdocs
         
     }
     
+
+    function afterODTCreation($parameters, &$object, &$action, $hookmanager)
+    {
+        global $conf;
+        
+        if(!empty($conf->global->ODTDOCS_REPLACE_ADD_PDF_CONV_TO_STD_ODT))
+        {
+            dol_include_once('odtdocs/define.php');
+            dol_include_once('odtdocs/class/odt.class.php');
+            
+            $res = TODTDocs::convertToPDF($parameters['file']);
+
+            if(!empty($conf->global->ODTDOCS_KEEP_ONLY_PDF)) {
+                @unlink($parameters['file']);
+            }
+        }
+    }
     
     
     function afterPDFCreation($parameters, &$object, &$action, $hookmanager)

--- a/class/actions_odtdocs.class.php
+++ b/class/actions_odtdocs.class.php
@@ -71,7 +71,7 @@ class ActionsOdtdocs
         
         if(!empty($conf->global->ODTDOCS_REPLACE_ADD_PDF_CONV_TO_STD_ODT))
         {
-            dol_include_once('odtdocs/define.php');
+            //dol_include_once('odtdocs/define.php');
             dol_include_once('odtdocs/class/odt.class.php');
             
             $res = TODTDocs::convertToPDF($parameters['file']);

--- a/class/odt.class.php
+++ b/class/odt.class.php
@@ -662,50 +662,9 @@ class TODTDocs {
 	}
 
 	static function convertToPDF($file) {
-		$infos = pathinfo($file);
-		$filepath = $infos['dirname'];
-			
-		if(defined('USE_ONLINE_SERVICE')) {
-			
-			//print USE_ONLINE_SERVICE;				
-			$postdata = http_build_query(
-			    array(
-			        'f1Data' => file_get_contents($file)
-					,'f1'=>basename($file)
-			    )
-			);
-			
-			$opts = array('http' =>
-			    array(
-			        'method'  => 'POST',
-			        'header'  => 'Content-type: application/x-www-form-urlencoded',
-			        'content' => $postdata
-			    )
-			);
-			
-			$context  = stream_context_create($opts);
-			//print USE_ONLINE_SERVICE;
-			$result = file_get_contents(USE_ONLINE_SERVICE, false, $context);
-			//exit($result);
-			$filePDF = $filepath.'/'.basename($result);
-			
-			copy(strtr($result, array(' '=>'%20')), $filePDF); 
-			//exit($result.', '.$filePDF);
-			return $filePDF;
-		}	
-		else {
-	//		print "Conversion locale en PDF";
-			// Transformation en PDF
-			ob_start();
-
-			 $cmd = 'export HOME=/tmp'."\n";
-			$cmd.=CMD_CONVERT_TO_PDF.' "'.$filepath.'" "'.$file.'"';
-
-			system($cmd);
-			$res = ob_get_clean();
-			return $res;
-
-		}	
+	    
+	    dol_include_once('abricot/includes/class/class.template.tbs.php');
+	    return TTemplateTBS::convertToPDF($file);
 	}
 
 	function getTVA(&$object) {

--- a/config.default.php
+++ b/config.default.php
@@ -27,9 +27,4 @@
 
 define('DOL_ADMIN_USER','admin');
 
-//define('USE_ONLINE_SERVICE','http://pdfservice.atm-consulting.fr/pdf.php');
-
-define('PATH_TO_LIBREOFFICE', 'libreoffice');
-//define('PATH_TO_LIBREOFFICE', '"C:\Program Files (x86)\LibreOffice 4.0\program\soffice.exe"');
-
-define('CMD_CONVERT_TO_PDF', PATH_TO_LIBREOFFICE.' --invisible --norestore --headless --convert-to pdf --outdir');
+include_once __DIR__ . '/define.php'; // use for odt to PDF conversion

--- a/core/modules/modOdtdocs.class.php
+++ b/core/modules/modOdtdocs.class.php
@@ -100,7 +100,7 @@ class modOdtdocs extends DolibarrModules
 		
 		$this->module_parts = array(
             'hooks' => array(
-                'pdfgeneration','formmail'
+                'pdfgeneration','formmail','odtgeneration'
             )
         );
 		

--- a/define.php
+++ b/define.php
@@ -1,0 +1,7 @@
+<?php 
+
+//define('USE_ONLINE_SERVICE','http://pdfservice.atm-consulting.fr/pdf.php');
+//define('PATH_TO_LIBREOFFICE', '"C:\Program Files (x86)\LibreOffice 4.0\program\soffice.exe"');
+
+if(!defined('PATH_TO_LIBREOFFICE')) define('PATH_TO_LIBREOFFICE', 'libreoffice');
+if(!defined('CMD_CONVERT_TO_PDF')) define('CMD_CONVERT_TO_PDF', PATH_TO_LIBREOFFICE.' --invisible --norestore --headless --convert-to pdf --outdir');

--- a/langs/fr_FR/odtdocs.lang
+++ b/langs/fr_FR/odtdocs.lang
@@ -35,3 +35,6 @@ ReplaceStandardPDFonGenerationByLastCustom=Remplacer le PDF standard par le dern
 ODTDOCS_CAN_GENERATE_ODT=Afficher le bouton pour la génération ODT
 ODTDOCS_CAN_GENERATE_PDF=Afficher le bouton pour la génération PDF
 ODTDOCS_SHOW_MESSAGE_ON_GENERATION=Afficher le texte d'information sur génération du document
+DefaultDolibarrODT=Comportement pour les fichiers ODT standard de Dolibarr
+setODTDOCS_REPLACE_ADD_PDF_CONV_TO_STD_ODT=Lorsque cela est possible, convertir les odt générés en PDF
+setODTDOCS_KEEP_ONLY_PDF=Après la génération du PDF, ne pas conserver le fichier .odt

--- a/langs/fr_FR/odtdocs.lang
+++ b/langs/fr_FR/odtdocs.lang
@@ -38,3 +38,4 @@ ODTDOCS_SHOW_MESSAGE_ON_GENERATION=Afficher le texte d'information sur générat
 DefaultDolibarrODT=Comportement pour les fichiers ODT standard de Dolibarr
 setODTDOCS_REPLACE_ADD_PDF_CONV_TO_STD_ODT=Lorsque cela est possible, convertir les odt générés en PDF
 setODTDOCS_KEEP_ONLY_PDF=Après la génération du PDF, ne pas conserver le fichier .odt
+ODTDOCS_needAbricotUpdate=Vous devez mettre à jour le module Abricot pour utiliser les options suivantes :


### PR DESCRIPTION
Ajout de 2 nouvelles options pour les fichiers ODT standard de Dolibarr:
* Lorsque cela est possible, convertir les odt générés en PDF
* Après la génération du PDF, ne pas conserver le fichier odt